### PR TITLE
move Config to hexomap package directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,7 @@ dmypy.json
 
 ### Python Patch ###
 .venv/
+
+### Local test files ###
+tmp_*
+

--- a/ConfigExample.yml
+++ b/ConfigExample.yml
@@ -1,0 +1,55 @@
+#############################################################################
+# Experiment configurations
+#############################################################################
+energy: 65.351 #keV
+detJ: [[1020.4672, 1035.6063]] #number of pixels
+detK: [[1995.8868, 1990.6409]] #number of pixels
+detL: [[ 8.9587, 10.9587]] #mm 
+detRot: [[[89.0107, 91.0776, -0.4593],[88.8744, 90.8149, -0.4466]]]  #degree
+detNJ: [2048, 2048, 2048, 2048]
+detNK: [2048, 2048, 2048, 2048]
+detPixelJ: [0.00148,0.00148,0.00148,0.00148] #mm
+detPixelK: [0.00148,0.00148,0.00148,0.00148] #mm
+
+Omega-Range: [ -90 , 90] #degree
+NRot: 180
+NDet: 2
+
+reverseRot: true # for aero, is True, for rams: False
+
+
+
+#############################################################################
+# Configuration for material
+#############################################################################
+
+sample: 'gold'
+fileFZ: 'hexomap/data/fundamental_zon/cubic.dat'
+
+
+
+#############################################################################
+# Reconstruction parameters
+#############################################################################
+
+etalimit:  1.4137 # radian
+maxQ:       8
+micsize: [150,150]
+micVoxelSize: 0.007 #mm
+micShift: [0,0,0]
+searchBatchSize: 10000
+
+
+
+#############################################################################
+# Files and file path
+#############################################################################
+
+expdataNdigit: 6
+fileBin: 'binary_file_initial'
+fileBinDigit: 6
+fileBinDetIdx: [0,1]
+fileBinLayerIdx: 0
+_initialString: 'demo_gold_'
+
+

--- a/demo_notebooks/Demo_Johnson_Aug18.ipynb
+++ b/demo_notebooks/Demo_Johnson_Aug18.ipynb
@@ -4,13 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Demo of NF-HEDM reconstruction using g-force"
+    "# Demo of NF-HEDM reconstruction using HEXOMAP\n",
+    "> requires python version >= 3.7"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os \n",
@@ -21,7 +24,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -48,11 +53,16 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "# integrate binary\n",
     "#\n",
+    "# this step can be skipped if the images are already interated into 1 degree omega step\n",
     "output='/home/hedm/work/suter_aug18/johnson_aug18/Au_reduced_1degree/Au_int_1degree_suter_aug18_z0_'\n",
     "ImagePar={'nDetectors':4,\n",
     "        'sBinFilePrefix':'/home/hedm/work/suter_aug18/johnson_aug18/Au_reduced/Au_johnson_aug18_z0_',\n",
@@ -86,7 +96,7 @@
     "import IntBin\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "rawInitial = '../data/johnson_aug18_demo/Au_reduced_1degree//Au_int_1degree_suter_aug18_z'\n",
+    "rawInitial = '../data/johnson_aug18_demo/Au_reduced_1degree/Au_int_1degree_suter_aug18_z'\n",
     "NRot = 30   # only number of images to display, doen't have to be all images(no need set to 180 or 720.can be some thing like 10)\n",
     "NDet = 2\n",
     "idxLayer = 0\n",
@@ -131,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -142,15 +152,10 @@
       "Configurations:\n",
       "NDet                           2\n",
       "NRot                           180\n",
-      "_Config__name                  name\n",
       "_initialString                 demo_gold_\n",
       "detJ                           [[1020.4672 1035.6063]]\n",
       "detK                           [[1995.8868 1990.6409]]\n",
       "detL                           [[4.5 6.5]]\n",
-      "detNJ                          [2048 2048 2048 2048]\n",
-      "detNK                          [2048 2048 2048 2048]\n",
-      "detPixelJ                      [0.00148 0.00148 0.00148 0.00148]\n",
-      "detPixelK                      [0.00148 0.00148 0.00148 0.00148]\n",
       "detRot                         [[[90 90  0]\n",
       "  [90 90  0]]]\n",
       "energy                         65.351\n",
@@ -168,44 +173,43 @@
       "reverseRot                     True\n",
       "sample                         gold\n",
       "searchBatchSize                6000\n",
-      "\n",
       "\n"
      ]
     }
    ],
    "source": [
     "import sys\n",
-    "sys.path.insert(0, '/home/heliu/work/dev/HEXOMAP/')\n",
+    "sys.path.insert(0, '/home/fyshen13/HEXOMAP/')\n",
     "import config\n",
     "import numpy as np\n",
     "\n",
-    "class Au_Config(config.Config):\n",
-    "    micsize = np.array([20, 20])\n",
-    "    micVoxelSize = 0.001\n",
-    "    micShift = np.array([0.0, 0.0, 0.0])\n",
-    "    expdataNDigit = 6\n",
-    "    energy = 65.351         #55.587 # in kev\n",
-    "    sample = 'gold'\n",
-    "    maxQ = 9\n",
-    "    etalimit = 81 / 180.0 * np.pi\n",
-    "    NRot = 180\n",
-    "    NDet = 2\n",
-    "    searchBatchSize = 6000\n",
-    "    reverseRot = True          # for aero, is True, for rams: False\n",
-    "    detL = np.array([[ 4.5, 6.5]])\n",
-    "    detJ = np.array([[1020.4672, 1035.6063]]) \n",
-    "    detK = np.array([[1995.8868, 1990.6409]])\n",
-    "    detRot = np.array([[[90, 90, 0],\n",
-    "                  [90, 90, 0]]])\n",
-    "    fileBin = '../data/johnson_aug18_demo/Au_reduced_1degree//Au_int_1degree_suter_aug18_z'\n",
-    "    fileBinDigit = 6\n",
-    "    fileBinDetIdx = np.array([0, 1])\n",
-    "    fileBinLayerIdx = 0\n",
-    "    fileFZ = '/home/heliu/work/dev/HEXOMAP/data/FZ_files/CubicFZ.dat'\n",
-    "    _initialString = 'demo_gold_'\n",
+    "Au_Config={\n",
+    "    'micsize' : np.array([20, 20]),\n",
+    "    'micVoxelSize' : 0.001,\n",
+    "    'micShift' : np.array([0.0, 0.0, 0.0]),\n",
+    "    'expdataNDigit' : 6,\n",
+    "    'energy' : 65.351,      #55.587 # in kev\n",
+    "    'sample' : 'gold',\n",
+    "    'maxQ' : 9,\n",
+    "    'etalimit' : 81 / 180.0 * np.pi,\n",
+    "    'NRot' : 180,\n",
+    "    'NDet' : 2,\n",
+    "    'searchBatchSize' : 6000,\n",
+    "    'reverseRot' : True,          # for aero, is True, for rams: False\n",
+    "    'detL' : np.array([[ 4.5, 6.5]]),\n",
+    "    'detJ' : np.array([[1020.4672, 1035.6063]]),\n",
+    "    'detK' : np.array([[1995.8868, 1990.6409]]),\n",
+    "    'detRot' : np.array([[[90, 90, 0],\n",
+    "                  [90, 90, 0]]]),\n",
+    "    'fileBin' : '../data/johnson_aug18_demo/Au_reduced_1degree//Au_int_1degree_suter_aug18_z',\n",
+    "    'fileBinDigit' : 6,\n",
+    "    'fileBinDetIdx' : np.array([0, 1]),\n",
+    "    'fileBinLayerIdx' : 0,\n",
+    "    'fileFZ' : '/home/heliu/work/dev/HEXOMAP/data/FZ_files/CubicFZ.dat',\n",
+    "    '_initialString' : 'demo_gold_'}\n",
     "    \n",
-    "c = Au_Config()\n",
-    "c.display()"
+    "c = config.Config(**Au_Config)\n",
+    "print(c)"
    ]
   },
   {
@@ -316,13 +320,7 @@
       " new parameters: [[1015.2375 1025.7892]], [[2016.5105 2012.894 ]], [[4.5198 6.5198]],07.0168  51.9392 188.3281] \n",
       " max hitratio:0.7183098793029785, rangeL:0.02640401243871794, rangeJ:2.1123209950974347, rangeK:1.0561604975487173\n",
       " new parameters: [[1014.3628 1024.8074]], [[2015.9393 2012.2871]], [[4.5233 6.5233]],40.2357  38.7487 349.6804] \n",
-      " max hitratio:0.6760563254356384, rangeL:0.02244341057291025, rangeJ:1.7954728458328193, rangeK:0.8977364229164096\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      " max hitratio:0.6760563254356384, rangeL:0.02244341057291025, rangeJ:1.7954728458328193, rangeK:0.8977364229164096\n",
       " new parameters: [[1014.3628 1024.771 ]], [[2015.9393 2012.2568]], [[4.5233 6.5233]],40.2352  38.7538 349.6765] \n",
       " max hitratio:0.6760563254356384, rangeL:0.019076898986973713, rangeJ:1.5261519189578963, rangeK:0.7630759594789481\n",
       "[[4.5233 6.5233]] [[1014.3628 1024.771 ]] [[2015.9393 2012.2568]] [[[ 9.0001e+01  9.0002e+01 -6.8826e-04]\n",
@@ -345,7 +343,7 @@
     "    pass\n",
     "\n",
     "S = reconstruction.Reconstructor_GPU()\n",
-    "c.display()\n",
+    "print(c)\n",
     "S.load_config(c)\n",
     "c.detL, c.detJ, c.detK, c.detRot = S.geo_opt_phase_0(centerL=np.array(c.detL), rotOptimization=True)\n",
     "print(c.detL, c.detJ, c.detK, c.detRot)\n",
@@ -443,12 +441,11 @@
     "import numpy as np\n",
     "import reconstruction\n",
     "import MicFileTool\n",
-    "c = config.Config()\n",
-    "c.load('../data/johnson_aug18_demo/demo_gold_blind_search_0.h5')\n",
+    "c = config.Config.load('../data/johnson_aug18_demo/demo_gold_blind_search_0.h5')\n",
     "c.micsize = np.array([20, 20])\n",
     "c.micVoxelSize = 0.005\n",
     "c.micShift = np.array([0.0, 0.0, 0.0])\n",
-    "c.display()\n",
+    "print(c)\n",
     "\n",
     "try:\n",
     "    S.clean_up()\n",
@@ -1001,13 +998,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000061.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000062.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000063.bin0\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000015.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000015.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000064.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000065.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000066.bin0\n",
@@ -1084,13 +1075,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000123.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000030.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000124.bin0\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000125.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000125.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000126.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000127.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000031.bin0\n",
@@ -1163,13 +1148,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000181.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000182.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000183.bin0\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000045.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000045.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000184.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000185.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000186.bin0\n",
@@ -1243,13 +1222,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000240.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000241.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000242.bin0\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000243.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000243.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000060.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000244.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000245.bin0\n",
@@ -1328,13 +1301,7 @@
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000075.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000304.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000305.bin0\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000306.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000306.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000307.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000076.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000308.bin0\n",
@@ -1408,13 +1375,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000363.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000090.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000364.bin0\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000365.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000365.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000366.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000367.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000091.bin0\n",
@@ -1497,13 +1458,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000429.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000430.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000431.bin0\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000107.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000107.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000432.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000433.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000434.bin0\n",
@@ -1588,13 +1543,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000497.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000498.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000499.bin0\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000124.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000124.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000500.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000501.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000502.bin0\n",
@@ -1668,13 +1617,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000556.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000557.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000558.bin0\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000559.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000559.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000139.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000560.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000561.bin0\n",
@@ -1748,13 +1691,7 @@
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000153.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000616.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000617.bin0\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000618.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000618.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000619.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000154.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000620.bin0\n",
@@ -1837,13 +1774,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000682.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000683.bin0\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000170.bin0\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000684.bin0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000684.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000685.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000686.bin0\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000687.bin0\n",
@@ -1927,13 +1858,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000029.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000030.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000031.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000007.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000007.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000032.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000033.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000034.bin1\n",
@@ -2013,13 +1938,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000093.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000094.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000095.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000023.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000023.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000096.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000097.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000098.bin1\n",
@@ -2101,13 +2020,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000159.bin1\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000039.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000160.bin1\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000161.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000161.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000162.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000163.bin1\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000040.bin1\n",
@@ -2185,13 +2098,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000221.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000222.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000223.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000055.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000055.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000224.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000225.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000226.bin1\n",
@@ -2272,13 +2179,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000286.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000287.bin1\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000071.bin1\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000288.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000288.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000289.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000290.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000291.bin1\n",
@@ -2367,13 +2268,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000357.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000358.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000359.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000089.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000089.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000360.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000361.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000362.bin1\n",
@@ -2448,13 +2343,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000417.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000418.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000419.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000104.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000104.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000420.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000421.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000422.bin1\n",
@@ -2544,13 +2433,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000489.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000490.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000491.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000122.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000122.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000492.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000493.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000494.bin1\n",
@@ -2625,13 +2508,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000549.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000550.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000551.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000137.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000137.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000552.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000553.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000554.bin1\n",
@@ -2716,13 +2593,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000617.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000618.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000619.bin1\n",
-      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000154.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000154.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000620.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000621.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000622.bin1\n",
@@ -2808,13 +2679,7 @@
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000686.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000687.bin1\n",
       "Writing: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_z0_000171.bin1\n",
-      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000688.bin1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000688.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000689.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000690.bin1\n",
       "Reading: /home/hedm/work/suter_aug18/SB1_v1_v2_boxbeam/SB1_postheat_restart_V1/SB1_postheat_restart_V1__z0_000691.bin1\n",
@@ -2935,7 +2800,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os \n",
@@ -2946,7 +2813,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "'''\n",
@@ -2958,35 +2827,33 @@
     "import config\n",
     "import numpy as np\n",
     "\n",
-    "c_Au = config.Config()\n",
-    "c_Au.load('../data/johnson_aug18_demo/demo_gold_twiddle_3.h5')\n",
-    "\n",
-    "class Fe_Config(config.Config):\n",
-    "    micsize = np.array([150, 150])\n",
-    "    micVoxelSize = 0.01\n",
-    "    micShift = np.array([0.0, 0.0, 0.0])\n",
-    "    expdataNDigit = 6\n",
-    "    energy = 65.351         #55.587 # in kev\n",
-    "    sample = 'iron_bcc'\n",
-    "    maxQ = 9\n",
-    "    etalimit = 81 / 180.0 * np.pi\n",
-    "    NRot = 180\n",
-    "    NDet = 2\n",
-    "    searchBatchSize = 6000\n",
-    "    reverseRot = True          # for aero, is True, for rams: False\n",
-    "    detL = c_Au.detL\n",
-    "    detJ = c_Au.detJ\n",
-    "    detK = c_Au.detK\n",
-    "    detRot = c_Au.detRot\n",
-    "    fileBin = '../data/johnson_aug18_demo/SB1_postheat_restart_V1_1degree/SB1_V1_1degree_z'\n",
-    "    fileBinDigit = 6\n",
-    "    fileBinDetIdx = np.array([0, 1])\n",
-    "    fileBinLayerIdx = 0\n",
-    "    fileFZ = '../data/FZ_files/CubicFZ.dat'\n",
-    "    _initialString = '../data/johnson_aug18_demo/SB1_postheat_restart_V1_1degree'\n",
-    "    \n",
-    "c = Fe_Config()\n",
-    "c.display()\n",
+    "c_Au = config.Config.load('../data/johnson_aug18_demo/demo_gold_twiddle_3.h5')\n",
+    "Fe_Config={\n",
+    "    'micsize' : np.array([150, 150]),\n",
+    "    'micVoxelSize' : 0.01,\n",
+    "    'micShift' : np.array([0.0, 0.0, 0.0]),\n",
+    "    'expdataNDigit' : 6,\n",
+    "    'energy' : 65.351,      #55.587 # in kev\n",
+    "    'sample' : 'iron_bcc',\n",
+    "    'maxQ' : 9,\n",
+    "    'etalimit' : 81 / 180.0 * np.pi,\n",
+    "    'NRot' : 180,\n",
+    "    'NDet' : 2,\n",
+    "    'searchBatchSize' : 6000,\n",
+    "    'reverseRot' : True,          # for aero, is True, for rams: False\n",
+    "    'detL' : c_Au.detL,\n",
+    "    'detJ' : c_Au.detJ,\n",
+    "    'detK' : c_Au.detK,\n",
+    "    'detRot' : c_Au.detRot,\n",
+    "    'fileBin' : '../data/johnson_aug18_demo/SB1_postheat_restart_V1_1degree/SB1_V1_1degree_z',\n",
+    "    'fileBinDigit' : 6,\n",
+    "    'fileBinDetIdx' : np.array([0, 1]),\n",
+    "    'fileBinLayerIdx' : 0,\n",
+    "    'fileFZ' : '../data/FZ_files/CubicFZ.dat',\n",
+    "    '_initialString' : '../data/johnson_aug18_demo/SB1_postheat_restart_V1_1degree'}\n",
+    "  \n",
+    "c = config.Config(**Fe_Config)\n",
+    "print(c)\n",
     "c.save('../data/johnson_aug18_demo/SB1_postheat_restart_V1_1degree_config.h5')"
    ]
   },
@@ -3056,7 +2923,7 @@
     "import reconstruction\n",
     "import MicFileTool\n",
     "\n",
-    "c.display()\n",
+    "print(c)\n",
     "\n",
     "try:\n",
     "    S.clean_up()\n",
@@ -3357,7 +3224,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -3378,7 +3247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/hexomap/config.py
+++ b/hexomap/config.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 no BOM -*-
+
+
+"""
+Configuration handler for NF-HEDM reconstruction.  By default, both YAML and 
+HDF5 archive are supported.
+"""
+
+import numpy as np
+
+from hexomap.utility import load_yaml
+from hexomap.utility import write_yaml
+from hexomap.utility import load_h5
+from hexomap.utility import write_h5
+
+
+class Config:
+    """Container class for reconstruction/simulation configuration parameters"""
+    
+    def __init__(self, **config):
+        """
+        Description
+        -----------
+        Initialize the Config object
+
+        Parameters
+        ----------
+        config: dict
+            All necessary configuration parameters are represented by 
+            hey-value pairs
+
+        Returns
+        -------
+        None
+        """
+        for key in config.keys():
+            if isinstance(config[key],list):
+                setattr(self,key,np.array(config[key]))
+            else:
+                setattr(self,key,config[key])
+
+    def __repr__(self):
+        """Display Configuration values."""
+        return "\nConfigurations:\n" \
+             + "\n".join([f"{k:30} {v}" for k,v in self.__dict__.items()])
+    
+    @staticmethod
+    def load(fName: str='ConfigExample.yml') -> "Config":
+        """
+        Description
+        -----------
+        Generate a Config instance from yaml or hdf5 archive.
+
+        Parameters
+        ----------
+        fName: str
+                Name of the configure file.
+
+        Returns
+        -------
+        Config
+            Config instance based on given archive
+        """
+        print(f"Loading configuration from {fName}")
+        try:
+            dataMap = load_yaml(fName) if fName.endswith(('.yml','.yaml')) else load_h5(fName)
+        except:
+            raise TypeError("Configure file type must be yaml or hdf5.")
+        
+        return Config(**dataMap)
+
+    def save(self, fName: str='ConfigureFile.yml') -> None:
+        """
+        Description
+        -----------
+        Save the configuration to yaml or hdf5 file.
+
+        Parameters
+        ----------
+        fName: str
+                Name of the configure file.
+
+        Returns
+        -------
+        None
+        """
+        _d = {}
+        for key, val in self.__dict__.items():
+            _d[key] = val.tolist() if isinstance(val, np.ndarray) else val
+
+        try:
+            write_yaml(fName, _d) if fName.endswith(('.yml','.yaml')) else write_h5(fName, self.__dict__)
+        except:
+            raise IOError(f"Cannout write {fName} to disk, need to be yml or h5")
+
+
+if __name__ == "__main__":
+    # testing loading yaml config file
+    import os
+    import hexomap
+    from pprint import pprint
+    exampleConfigFile = os.path.join(
+        os.path.dirname(hexomap.__file__),
+        "data/configs/ConfigExample.yml",
+    )
+    config = Config.load(exampleConfigFile)
+    print(config)
+
+    config.save('../tmp_test.yml')
+    config.save('../tmp_test.h5')

--- a/hexomap/data/configs/ConfigExample.yml
+++ b/hexomap/data/configs/ConfigExample.yml
@@ -1,0 +1,55 @@
+#############################################################################
+# Experiment configurations
+#############################################################################
+energy: 65.351 #keV
+detJ: [[1020.4672, 1035.6063]] #number of pixels
+detK: [[1995.8868, 1990.6409]] #number of pixels
+detL: [[ 8.9587, 10.9587]] #mm 
+detRot: [[[89.0107, 91.0776, -0.4593],[88.8744, 90.8149, -0.4466]]]  #degree
+detNJ: [2048, 2048, 2048, 2048]
+detNK: [2048, 2048, 2048, 2048]
+detPixelJ: [0.00148,0.00148,0.00148,0.00148] #mm
+detPixelK: [0.00148,0.00148,0.00148,0.00148] #mm
+
+Omega-Range: [ -90 , 90] #degree
+NRot: 180
+NDet: 2
+
+reverseRot: true # for aero, is True, for rams: False
+
+
+
+#############################################################################
+# Configuration for material
+#############################################################################
+
+sample: 'gold'
+fileFZ: 'hexomap/data/fundamental_zon/cubic.dat'
+
+
+
+#############################################################################
+# Reconstruction parameters
+#############################################################################
+
+etalimit:  1.4137 # radian
+maxQ:       8
+micsize: [150,150]
+micVoxelSize: 0.007 #mm
+micShift: [0,0,0]
+searchBatchSize: 10000
+
+
+
+#############################################################################
+# Files and file path
+#############################################################################
+
+expdataNdigit: 6
+fileBin: 'binary_file_initial'
+fileBinDigit: 6
+fileBinDetIdx: [0,1]
+fileBinLayerIdx: 0
+_initialString: 'demo_gold_'
+
+

--- a/hexomap/utility.py
+++ b/hexomap/utility.py
@@ -4,6 +4,8 @@
 Utility module for hexomap package.
 """
 
+import yaml
+import h5py
 import numpy as np
 
 from functools import singledispatch
@@ -53,5 +55,75 @@ def standarize_euler(euler: np.ndarray, in_radian=True) -> np.ndarray:
         )
 
 
+def load_yaml(fname: str) -> dict:
+    """generic safe_load wrapper for yaml archive"""
+    try:
+        with open(fname, 'r') as f:
+            dataMap = yaml.safe_load(f)
+    except IOError as e:
+        print(f"Cannot open YAML file {fname}")
+        print(f"IOError: {e}")
+    
+    return dataMap
+
+
+def write_yaml(fname: str, data: dict) -> None:
+    """generic output handler for yaml archive"""
+    try:
+        with open(fname, 'w') as f:
+            yaml.safe_dump(data, f, default_flow_style=False)
+    except IOError as e:
+        print(f"Cannot write YAML file {fname}")
+        print(f"IOError: {e}")
+
+
+def write_h5(fname: str, data: dict) -> None:
+    """generic simper HDF5 archive writer"""
+    try:
+        with h5py.File(fname, 'w') as f:
+            recursively_save_dict_contents_to_group(f,'/',data)
+    except IOError as e:
+        print(f"Cannot write HDF5 file {fname}")
+        print(f"IOError: {e}")
+
+
+def load_h5(fname: str, path: str='/') -> dict:
+    """generic simple HDF5 archive loader"""
+    try:
+        with h5py.File(fname, 'r') as f:
+            dataMap = recursively_load_dict_contents_from_group(f, path)
+    except IOError as e:
+        print(f"Cannot open HDF5 file {fname}")
+        print(f"IOError: {e}")
+
+    return dataMap
+
+
+def recursively_load_dict_contents_from_group(h5file: "h5py.File", 
+                                              path: str,
+        ) -> dict:
+    """recursively load data from HDF5 archive as dict"""
+    ans = {}
+    for key, item in h5file[path].items():
+        if isinstance(item, h5py._hl.dataset.Dataset):
+            ans[key] = item.value
+        elif isinstance(item, h5py._hl.group.Group):
+            ans[key] = recursively_load_dict_contents_from_group(h5file, f"{path}{key}/")
+    return ans
+
+
+def recursively_save_dict_contents_to_group(h5file: "h5py.File", 
+                                            path: str, 
+                                            dic: dict,
+        ) -> None:
+    """recursively write data to HDF5 archive"""
+    for key, item in dic.items():
+        if isinstance(item, (np.ndarray, np.int64, np.float64, str, bytes,int,float,np.bool_)):
+            h5file[path + key] = item
+        elif isinstance(item, dict):
+            recursively_save_dict_contents_to_group(h5file, path + key + '/', item)
+        else:
+            raise ValueError(f'Cannot save {item} type')
+            
 if __name__ == "__main__":
     pass

--- a/makefile
+++ b/makefile
@@ -28,4 +28,3 @@ clean:
 	@echo "Clean up workbench"
 	rm  -fv   *.tmp
 	rm  -fv   tmp_*
-

--- a/reconstruction.py
+++ b/reconstruction.py
@@ -218,7 +218,7 @@ class Reconstructor_GPU():
             self.sample.PrimB = value * np.array([0, 1, 0])
             self.sample.PrimC = value * np.array([0, 0, 1])
         else: 
-                raise ValueError('not implemented') #todo@hel1 not implemented error
+            raise ValueError('not implemented') #todo@hel1 not implemented error
         self.sample.getRecipVec()
         self.sample.getGs(self.maxQ)
         self.NG = self.sample.Gs.shape[0]


### PR DESCRIPTION
move the Config class definition to __hexomap__ package directory with the following modifications:

* extract the YML and HDF5 loader and writer to _hexomap.utility_ as these are useful and generic enough for other modules to use.
* use __dict__ instead of dir() since we are only interested in the attributes of instances of Config class
* use f-string for string formatting
* switch from _classmethod_ to _staticmethod_ for Config.load()
* add type hinting to functions
* add example usage at the end of config.py

Others:
* update the Gitignore list to ignore local testing output
* fix an indentation error in the reconstruction.py
* the original config.py remains in the project root
