### PR TITLE
add a "save_as_h5" function to save reconstruction result

### DIFF
--- a/hexomap/reconstruction.py
+++ b/hexomap/reconstruction.py
@@ -782,9 +782,10 @@ class Reconstructor_GPU():
         config: Config(), defined in config.py
         '''
         try:
-            getattr(config, 'micMask')         
+            getattr(config, 'micMask')        
+            micMask=config.micMask
         except AttributeError:
-            config.micMask = None
+            micMask = None
         self.etalimit = config.etalimit
         self.set_sample(config.sample)
         self.set_Q(config.maxQ)
@@ -799,7 +800,7 @@ class Reconstructor_GPU():
         self.create_square_mic(config.micsize,
                             voxelsize=config.micVoxelSize,
                             shift=config.micShift,
-                            mask=config.micMask,
+                            mask=micMask,
                            )# resolution of reconstruction and voxel size
         self.squareMicOutFile = f'{config._initialString}_q{self.maxQ}_rot{self.NRot}_z{config.fileBinLayerIdx}_' \
                             + f'{"x".join(map(str,config.micsize))}_{config.micVoxelSize}' \
@@ -862,12 +863,14 @@ class Reconstructor_GPU():
             if not os.path.isfile(fName):
                 self.config.save(fName)
             else:
-                print("{} already exists, skip saving configuration")
+                print("{:} already exists, skip saving configuration".format(fName))
             print("Start saving layer {0:d} ...".format(layerIdx))
 
             with h5py.File(fName,'r+') as fout:
                 if not 'slices' in list(fout.keys()):
                     sls=fout.create_group('slices')
+                else:
+                    sls=fout['slices']
                 if 'z{:d}'.format(layerIdx) in list(fout['slices'].keys()):
                     print("Error: layer {0:d} already exists in {1:}".format(layerIdx,fName))
                 else:

--- a/hexomap/reconstruction.py
+++ b/hexomap/reconstruction.py
@@ -33,7 +33,7 @@ import scipy.misc
 import importlib
 from weakref import WeakValueDictionary
 import h5py
-from utility import print_h5
+from hexomap.utility import print_h5
 #global ctx
 #ctx = None
 #cuda.init()

--- a/hexomap/reconstruction.py
+++ b/hexomap/reconstruction.py
@@ -32,6 +32,8 @@ import sys
 import scipy.misc
 import importlib
 from weakref import WeakValueDictionary
+import h5py
+from utility import print_h5
 #global ctx
 #ctx = None
 #cuda.init()
@@ -804,6 +806,7 @@ class Reconstructor_GPU():
                             + f'_shift_{"_".join(map(str, config.micShift))}.npy' # output file name
         self.searchBatchSize = int(config.searchBatchSize)    # number of orientations search at each iteration, larger number will take longer time.
         self.recon_prepare(config.reverseRot, bReloadExpData=reloadData)
+        self.config=config
 
     def create_square_mic(self, shape=(100, 100), shift=[0, 0, 0], voxelsize=0.01, mask=None):
         '''
@@ -841,6 +844,49 @@ class Reconstructor_GPU():
             for jj in range(self.squareMicData.shape[1]):
                 self.squareMicData[ii, jj, 0:3] = (np.array([ii + 0.5, jj + 0.5, 0]) - midVoxel) * voxelsize + shift
         self.set_voxel_pos(self.squareMicData[:, :, :3].reshape([-1, 3]), self.squareMicData[:, :, 7].ravel())
+
+    def save_as_h5(self, layerIdx: int=0, fName: str='reconRes.hdf5') -> None:
+        """
+        Description
+        -----------
+        Save the reconstruction result with configurations to hdf5 file.
+        Parameters
+        ----------
+        fName: str
+                Name of the file.
+        Returns
+        -------
+        None
+        """
+        if fName.endswith(('.h5','.hdf5')):
+            if not os.path.isfile(fName):
+                self.config.save(fName)
+            else:
+                print("{} already exists, skip saving configuration")
+            print("Start saving layer {0:d} ...".format(layerIdx))
+
+            with h5py.File(fName,'r+') as fout:
+                if not 'slices' in list(fout.keys()):
+                    sls=fout.create_group('slices')
+                if 'z{:d}'.format(layerIdx) in list(fout['slices'].keys()):
+                    print("Error: layer {0:d} already exists in {1:}".format(layerIdx,fName))
+                else:
+                    a=self.squareMicData
+                    grp=sls.create_group('z{:d}'.format(layerIdx))
+                    ds=grp.create_dataset('x',data=a[:,:,0]*1000,dtype='float32')
+                    ds.attrs['info']='X coordinate (micron meter).'
+                    ds=grp.create_dataset('y',data=a[:,:,1]*1000,dtype='float32')
+                    ds.attrs['info']='Y coordinate (micron meter).'
+                    ds=grp.create_dataset('EulerAngles',data=a[:,:,3:6]*np.pi/180,dtype='float32')
+                    ds.attrs['info']='active ZXZ Euler angles (radian)'
+                    ds=grp.create_dataset('phase',data=a[:,:,7],dtype='uint16')
+                    ds.attrs['info']='material phases'
+                    ds=grp.create_dataset('Confidence',data=a[:,:,6],dtype='float32')
+                    ds.attrs['info']='hit ratio of simulated peaks and experimental peaks'
+            print('=== saved format:')
+            print_h5(fName)
+        else:
+            print("Result file name must end with 'h5' or 'hdf5'")
 
     def save_square_mic(self, fName, format='npy'):
         '''
@@ -2035,13 +2081,13 @@ if __name__ == "__main__":
     import os
     import hexomap
     c = config.Config().load('examples/johnson_aug18_demo/demo_gold_twiddle_3.h5')
-    c.display()
+    print(c)
     c.fileFZ = os.path.join( os.path.dirname(hexomap.__file__), 'data/fundamental_zone/cubic.dat')
     c.fileBin= 'examples/johnson_aug18_demo/Au_reduced_1degree/Au_int_1degree_suter_aug18_z'
     c.micVoxelSize = 0.005
     c.micsize = [15,15]
 
-    c.display()
+    print(c)
 
     try:
         S.clean_up()

--- a/hexomap/utility.py
+++ b/hexomap/utility.py
@@ -137,7 +137,7 @@ def recursively_save_dict_contents_to_group(h5file: "h5py.File",
         ) -> None:
     """recursively write data to HDF5 archive"""
     for key, item in dic.items():
-        if isinstance(item, (type(None),np.ndarray, np.int64, np.float64, str, bytes,int,float,np.bool_)):
+        if isinstance(item, (np.ndarray, np.int64, np.float64, str, bytes,int,float,np.bool_)):
             h5file[path + key] = item
         elif isinstance(item, dict):
             recursively_save_dict_contents_to_group(h5file, path + key + '/', item)

--- a/hexomap/utility.py
+++ b/hexomap/utility.py
@@ -102,7 +102,7 @@ def print_h5(fname: str) -> None:
     """generic simple HDF5 archive structure printer"""
     try:
         with h5py.File(fname, 'r') as h:
-            print(filename)
+            print(fname)
             recursively_print_structure(h, '  ')
     except IOError as e:
         print(f"Cannot open HDF5 file {fname}")
@@ -137,7 +137,7 @@ def recursively_save_dict_contents_to_group(h5file: "h5py.File",
         ) -> None:
     """recursively write data to HDF5 archive"""
     for key, item in dic.items():
-        if isinstance(item, (np.ndarray, np.int64, np.float64, str, bytes,int,float,np.bool_)):
+        if isinstance(item, (type(None),np.ndarray, np.int64, np.float64, str, bytes,int,float,np.bool_)):
             h5file[path + key] = item
         elif isinstance(item, dict):
             recursively_save_dict_contents_to_group(h5file, path + key + '/', item)

--- a/hexomap/utility.py
+++ b/hexomap/utility.py
@@ -98,6 +98,25 @@ def load_h5(fname: str, path: str='/') -> dict:
 
     return dataMap
 
+def print_h5(fname: str) -> None:
+    """generic simple HDF5 archive structure printer"""
+    try:
+        with h5py.File(fname, 'r') as h:
+            print(filename)
+            recursively_print_structure(h, '  ')
+    except IOError as e:
+        print(f"Cannot open HDF5 file {fname}")
+        print(f"IOError: {e}")
+
+def recursively_print_structure(item, leading = ''):
+    """recusively print HDF5 archive structure"""
+    for key in item:
+        if isinstance(item[key], h5py.Dataset):
+            print(leading + key + ': ' + str(item[key].shape))
+        else:
+            print(leading + key)
+            recursively_print_structure(item[key], leading + '  ')
+
 
 def recursively_load_dict_contents_from_group(h5file: "h5py.File", 
                                               path: str,


### PR DESCRIPTION
1. I added a "save_as_h5" function to save reconstruction result. It can save the configurations along with the reconstruction result. It can also save multiple slices in the same hdf5 file.

2. A reason that causes "config.save()" to fail is that function "Reconstructor_GPU.load_config()" added a new object member config.micMask=None, which cannot be saved in hdf5. I removed that.